### PR TITLE
Add handling for unknown origin values

### DIFF
--- a/iris/bot/__init__.py
+++ b/iris/bot/__init__.py
@@ -41,6 +41,8 @@ class Bot:
             self.emitter.emit("new_member", [chat])
         elif origin == "DELMEM":
             self.emitter.emit("del_member", [chat])
+        else:
+            self.emitter.emit("unknown", [chat])
 
     def __process_iris_request(self, req: IrisRequest):
         v = {}


### PR DESCRIPTION
## 알려지지 않은 origin 값 처리 추가

### 배경
@Siruu580가 요청한 기능을 구현하는 과정 중, MSG, NEWMEM, DELMEM 외의 값들이 처리되지 않는 문제를 발견했습니다. 이를 해결하기 위해 unknown origin 처리 로직을 추가했습니다.
 
### 변경사항
- `__process_chat` 메서드에 else 절 추가
- 알려지지 않은 origin 타입을 처리하는 `unknown` 이벤트 emit 추가
- 기존 동작에는 영향 없음

### 사용 예제
```python
@bot.on_event("unknown")
def handle_unknown_origin(chat: ChatContext):
    if chat.message.v["origin"] == "SYNCDLMSG":
        message = json.loads(chat.message.message)
        if message["feedType"] == 14:
            log_id = message["logId"]
            deleted_message = bot.api.query("SELECT * from chat_logs where id = ?", [log_id])[0].message
            chat.reply(f"⌈삭제된 메시지⌋\n{deleted_message}")