### PR TITLE
Fix:  Parse user_id as integer to resolve type mismatch

### DIFF
--- a/iris/cli.py
+++ b/iris/cli.py
@@ -466,11 +466,11 @@ def main():
     admin_subparsers = parser_admin.add_subparsers(dest="admin_action", required=True, help="Action for admin users.")
 
     admin_add = admin_subparsers.add_parser("add", help="Add a user to the admin list.")
-    admin_add.add_argument("user_id", help="The ID of the user to add as admin.")
+    admin_add.add_argument("user_id", type=int, help="The ID of the user to add as admin.")
     admin_add.set_defaults(func=handle_admin_commands)
 
     admin_del = admin_subparsers.add_parser("del", help="Remove a user from the admin list.")
-    admin_del.add_argument("user_id", help="The ID of the user to remove from admin.")
+    admin_del.add_argument("user_id", type=int, help="The ID of the user to remove from admin.")
     admin_del.set_defaults(func=handle_admin_commands)
 
     admin_list = admin_subparsers.add_parser("list", help="List all admin user IDs.")
@@ -481,16 +481,16 @@ def main():
     ban_subparsers = parser_ban.add_subparsers(dest="ban_action", required=True, help="Action for banned users.")
 
     ban_add = ban_subparsers.add_parser("add", help="Add a user to the ban list.")
-    ban_add.add_argument("user_id", help="The ID of the user to ban.")
+    ban_add.add_argument("user_id", type=int, help="The ID of the user to ban.")
     ban_add.set_defaults(func=handle_ban_commands)
 
     ban_del = ban_subparsers.add_parser("del", help="Remove a user from the ban list.")
-    ban_del.add_argument("user_id", help="The ID of the user to unban.")
+    ban_del.add_argument("user_id", type=int, help="The ID of the user to unban.")
     ban_del.set_defaults(func=handle_ban_commands)
 
     # Per specification: "iris ban list <user_id>" checks a specific user
     ban_list = ban_subparsers.add_parser("list", help="Check if a specific user is in the ban list.")
-    ban_list.add_argument("user_id", help="The ID of the user to check ban status for.")
+    ban_list.add_argument("user_id", type=int, help="The ID of the user to check ban status for.")
     ban_list.set_defaults(func=handle_ban_commands)
 
     # --- iris service ---


### PR DESCRIPTION
## user_id 인자 타입을 int로 명시하여 타입 불일치 문제 해결

### 문제 상황
argparse를 통해 입력받는 user_id의 타입이 지정되지 않아 기본값인 문자열(str)로 처리되고 있었습니다.

실제 데이터 핸들링 로직에서는 User.id를 int 타입으로 사용하고 있어, 값은 같아도 타입이 달라 admin_check() 함수나 ban_check() 함수가 항상 False를 반환하는 문제가 발생했습니다.

### 변경 사항
add_argument() 함수에 type=int 옵션을 추가하여, 커맨드 라인에서 입력받는 user_id를 처음부터 int 타입으로 파싱하도록 수정했습니다.