### PR TITLE
웹소켓 수신을 타임아웃으로 폴링해 Ctrl+C 즉시 종료 가능하게 수정

### DIFF
--- a/iris/bot/__init__.py
+++ b/iris/bot/__init__.py
@@ -88,7 +88,7 @@ class Bot:
                     self.bot_id = self.api.get_info()["bot_id"]
                     while True:
                         try:
-                            recv = ws.recv(timeout=1)
+                            recv = ws.recv(timeout=0.01)
                         except TimeoutError:
                             continue
 

--- a/iris/bot/__init__.py
+++ b/iris/bot/__init__.py
@@ -87,7 +87,11 @@ class Bot:
                     print("웹소켓에 연결되었습니다")
                     self.bot_id = self.api.get_info()["bot_id"]
                     while True:
-                        recv = ws.recv()
+                        try:
+                            recv = ws.recv(timeout=1)
+                        except TimeoutError:
+                            continue
+
                         try:
                             data: dict = json.loads(recv)
                             data["raw"] = data.get("json")


### PR DESCRIPTION
- Iris WebSocket을 0.01초 주기로 폴링하도록 `ws.recv(timeout=0.01)`을 사용해 Ctrl+C 신호를 바로 처리할 수 있게 했습니다.​
- 타임아웃이 발생하면 다음 메시지를 기다리도록 루프를 계속 돌면서 재시도합니다.​

이유: 프로세스 종료 명령이 바로 적용되지 않고 이벤트 루프를 빠져나와야 처리되는것이 불편해서